### PR TITLE
Fix issues when devices get added/removed by storing the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### AudioPick-0.2.3 - 2019-03-02
+- store audio device name instead of index to fix issues when devices get added/removed. One downside: Renaming a device will revert to the default one.
+
 ### AudioPick-0.2.2 - 2016-05-21
 - going stable
 - revert `page_action back` to `browser_action`

--- a/extension/background.html
+++ b/extension/background.html
@@ -8,6 +8,7 @@
 	<script src="background.js"></script>
 <body>
 	<option id="default_no" value="0"></option>
+	<option id="default_name" value="System Default Device"></option>
 	<select id="device_cache"></select>
 </body>
 </html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -38,17 +38,20 @@ function log(message) {
 }
 
 function update_default_no(e) {
-	log("update_default_no: " +  e.target.value);
+ 	console.log(e);
+	log("update_default_no: " +  e.target.value + " " + e.target.text);
 	var default_no =  bg.document.getElementById("default_no");
+	var default_name =  bg.document.getElementById("default_name");
 	default_no.value = e.target.value;
-	chrome.storage.local.set({"AP_default_no" : e.target.value});
+	default_name.value = e.target.text;
+	chrome.storage.local.set({"AP_default_name" : e.target.text});
 }
 
 function update_device_options(deviceInfos) {
 	log('update_device_options: ' + deviceInfos.length + ' device(s) total (audio/video input/output)');
 	var div = document.getElementById("device_options");
 	var select = bg.document.getElementById("device_cache");
-	var default_no = bg.document.getElementById("default_no");
+	var default_name = bg.document.getElementById("default_name");
 	while (div.firstChild) { div.removeChild(div.firstChild); }
 	for (var i = 0; i !== deviceInfos.length; ++i) {
 		var kind = deviceInfos[i].kind;
@@ -75,18 +78,19 @@ function update_device_options(deviceInfos) {
 				option = bg.document.createElement("option");
 				option.id = id;
 				option.value = text;
-				select.appendChild(option);				
+				select.appendChild(option);
 			}
 			var input = document.createElement("input");
 			input.type= "radio";
 			input.name = "device";
+			input.text = text;
 			input.id = id;
 			input.value = i;
 			input.onchange = function(e){update_default_no(e);};
 			var textNode = document.createTextNode(text);
 			var label = document.createElement("label");
-			if (i == default_no.value) {
-				log('current default_no: ' + i + ' - ' + id + ' - ' + text);
+			if (default_name && text == default_name.value) {
+				log('current default: ' + i + ' - ' + id + ' - ' + text);
 				input.checked = true;
 			}			
 			label.appendChild(input);

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -6,7 +6,9 @@
  
 var bg = chrome.extension.getBackgroundPage();
 var default_no = bg.document.getElementById("default_no");
+var default_name = bg.document.getElementById("default_name");
 var sink_no = default_no.value;
+var sink_name = default_name.value;
 
 // -- Update the temporary device selection page 
  function init() {
@@ -20,8 +22,9 @@ var sink_no = default_no.value;
 				{'frameId': 0}, // only request from main frame
 				function(response) {
 					if (response) {
-						log("Received Response: " + response.sink_no);
+						log("Received Response: " + response.sink_no + " " + response.sink_name);
 						sink_no = response.sink_no;
+						sink_name = response.sink_name;
 					}
 					navigator.mediaDevices.enumerateDevices()
 						.then(update_device_popup)
@@ -77,12 +80,13 @@ function update_device_popup(deviceInfos) {
 			input.type= "radio";
 			input.name = "device";
 			input.id = id;
+			input.text = text;
 			input.value = i;
 			input.onchange = function(e){input_onchange(e);};
 			var textNode = document.createTextNode(text);
 			var label = document.createElement("label");
-			if (i == sink_no) {
-				log('current default_no: ' + i + ' - ' + id + ' - ' + text);
+			if (sink_name && text == sink_name) {
+				log('current default: ' + i + ' - ' + id + ' - ' + text);
 				input.checked = true;
 			}			
 			label.appendChild(textNode);
@@ -94,14 +98,18 @@ function update_device_popup(deviceInfos) {
 
 function input_onchange(e) {
 	//log('browser_action Commit');
-	var sink_no = e.target.value;	
+	var sink_no = e.target.value;
+	var sink_id = e.target.id;
+	var sink_name = e.target.text;
 	chrome.tabs.query({active: true, currentWindow: true},
 		function(tabs) {
 			var activeTab = tabs[0];
-			log('Sending message: browser_action_commit, sink_no: ' + sink_no);
+			log('Sending message: browser_action_commit, sink_no: ' + sink_no + ', sink_name: ' + sink_name + ', sink_id: ' + sink_id);
 			chrome.tabs.sendMessage(activeTab.id, { // send to all frames without using options = {'frameId': N} 
 				"message": "browser_action_commit",
-				"sink_no":  sink_no
+				"sink_no":  sink_no,
+				"sink_name":  sink_name,
+				"sink_id": sink_id
 			});
 			window.close();
 		}


### PR DESCRIPTION
Previously the index was stored which changed every time you added or removed an audio device. Now the name of the device is stored (as device IDs don't seem to be consistent?) which only leads to issues when you rename the device you are currently using, otherwise it's resistant to changes to audio devices.